### PR TITLE
Adding support for new AMI (Amazon Linux 2)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,10 +69,20 @@ class ec2tagfacts::params {
       $enable_epel  = true
     }
     'Amazon': {
-      $pippkg       = undef
-      $rubyjsonpkg  = 'rubygem18-json'
-      $awscli       = 'aws-cli'
-      $enable_epel  = false
+      case $::operatingsystemrelease {
+      /^2/: {
+          $pippkg       = undef
+          $rubyjsonpkg  = 'rubygem-json'
+          $awscli       = 'awscli'
+          $enable_epel  = false
+        }
+        default: {
+          $pippkg       = undef
+          $rubyjsonpkg  = 'rubygem18-json'
+          $awscli       = 'aws-cli'
+          $enable_epel  = false
+        }
+      }
     }
     'ubuntu', 'debian': {
       $pippkg       = 'python-pip'


### PR DESCRIPTION
ami-0b898040803850657
rubygem18-json does not exist, added "case" to the Amazon OS params (OS based selection), release "2" is the new one, defaults is the same (e.g. applied to "2018.3" release). Also "awscli" instead of "aws-cli"